### PR TITLE
add mysql/php development to onshift playbook

### DIFF
--- a/onshift.yml
+++ b/onshift.yml
@@ -24,8 +24,10 @@
         }
       - { role: development, tags: development,
             development_environments: [
-                 postgresql,
-                 python,
+                mysql,
+                php,
+                postgresql,
+                python,
             ]
         }
       # Window management

--- a/roles/development/tasks/do_install.yml
+++ b/roles/development/tasks/do_install.yml
@@ -7,7 +7,8 @@
     state=latest
     update_cache=true
   when: ansible_distribution == 'Ubuntu'
-  with_items: development_packages
+  with_items:
+    - "{{ development_packages }}"
   register: development_packages_output
   tags: packages
 

--- a/roles/development/tasks/do_install_php.yml
+++ b/roles/development/tasks/do_install_php.yml
@@ -5,4 +5,5 @@
       src={{ item }}
       dest={{ ansible_env.HOME }}/{{ item }}
       mode=750
-  with_items: development_php_bin
+  with_items:
+    - "{{ development_php_bin }}"


### PR DESCRIPTION
Add php and mysql development packages to the onshift playbook.
Make the development role Ansible 2 compatible
